### PR TITLE
Re-enable dimensional and related packages

### DIFF
--- a/build-constraints.yaml
+++ b/build-constraints.yaml
@@ -2232,6 +2232,11 @@ packages:
         - hjsonpointer
         - hjsonschema
 
+    "Doug McClean <douglas.mcclean@gmail.com>":
+        - dimensional
+        - exact-pi
+        - numtype-dk
+
     # If you stop maintaining a package you can move it here.
     # It will then be disabled if it starts causing problems.
     # See https://github.com/fpco/stackage/issues/1056


### PR DESCRIPTION
These build on GHC 8 now.
